### PR TITLE
Fix timezone offset formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ TICKTICK_USER_TIMEZONE=Asia/Bangkok         # Bangkok
 
 **Supported Format**: Use IANA timezone names (e.g., `America/New_York`, `Europe/Berlin`, `Asia/Tokyo`).
 
+Date and time values provided without an explicit timezone will automatically
+use your configured timezone. For example, with
+`TICKTICK_USER_TIMEZONE=Asia/Bangkok` (UTC+7),
+`2025-06-11T15:00:00` will be interpreted as `2025-06-11T15:00:00+0700`.
+
 ## Authentication with Dida365
 
 [滴答清单 - Dida365](https://dida365.com/home) is China version of TickTick, and the authentication process is similar to TickTick. Follow these steps to set up Dida365 authentication:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,15 @@
+import importlib
+import os
+from ticktick_mcp.src import server
+
+
+def reload_server_with_tz(tz: str):
+    os.environ['TICKTICK_USER_TIMEZONE'] = tz
+    importlib.reload(server)
+
+
+def test_normalize_datetime_for_user():
+    reload_server_with_tz('Asia/Bangkok')  # UTC+7
+    result = server.normalize_datetime_for_user('2025-06-11T15:00:00')
+    assert result == '2025-06-11T15:00:00+0700'
+

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -140,14 +140,13 @@ def normalize_datetime_for_user(date_str: str) -> str:
         return date_str
     
     # If no timezone info, assume user timezone
-    if not re.search(r'[+-]\d{2}:?\d{2}|Z$', date_str):
+    if not re.search(r'([+-]\d{2}:?\d{2}|Z)$', date_str):
         user_offset = datetime.now(USER_TIMEZONE).strftime('%z')
-        formatted_offset = f"{user_offset[:3]}:{user_offset[3:]}"
-        
+
         if 'T' in date_str:
-            return date_str + formatted_offset
+            return date_str + user_offset
         else:
-            return date_str + f'T00:00:00{formatted_offset}'
+            return date_str + f'T00:00:00{user_offset}'
     
     return date_str
 


### PR DESCRIPTION
## Summary
- honor the timezone offset returned by strftime directly
- anchor timezone offset regex when normalizing
- document implicit timezone example in README
- add a unit test for `normalize_datetime_for_user`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684952cc613c832685edfd7d6f254dfd