### PR TITLE
Fix timezone offset formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ TICKTICK_USER_TIMEZONE=Asia/Bangkok         # Bangkok
 
 **Supported Format**: Use IANA timezone names (e.g., `America/New_York`, `Europe/Berlin`, `Asia/Tokyo`).
 
+Date and time values provided without an explicit timezone will automatically
+use your configured timezone. For example, with
+`TICKTICK_USER_TIMEZONE=Asia/Bangkok` (UTC+7),
+`2025-06-11T15:00:00` will be interpreted as `2025-06-11T15:00:00+0700`.
+
 ## Authentication with Dida365
 
 [滴答清单 - Dida365](https://dida365.com/home) is China version of TickTick, and the authentication process is similar to TickTick. Follow these steps to set up Dida365 authentication:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,15 @@
+import importlib
+import os
+from ticktick_mcp.src import server
+
+
+def reload_server_with_tz(tz: str):
+    os.environ['TICKTICK_USER_TIMEZONE'] = tz
+    importlib.reload(server)
+
+
+def test_normalize_datetime_for_user():
+    reload_server_with_tz('Asia/Bangkok')  # UTC+7
+    result = server.normalize_datetime_for_user('2025-06-11T15:00:00')
+    assert result == '2025-06-11T15:00:00+0700'
+

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -24,8 +24,6 @@ mcp = FastMCP("ticktick")
 # Create TickTick client
 ticktick = None
 
-import os
-from zoneinfo import ZoneInfo
 
 # User timezone configuration  
 UTC_TIMEZONE = ZoneInfo("UTC")

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -140,14 +140,13 @@ def normalize_datetime_for_user(date_str: str) -> str:
         return date_str
     
     # If no timezone info, assume user timezone
-    if not re.search(r'[+-]\d{2}:?\d{2}|Z$', date_str):
+    if not re.search(r'([+-]\d{2}:?\d{2}|Z)$', date_str):
         user_offset = datetime.now(USER_TIMEZONE).strftime('%z')
-        formatted_offset = f"{user_offset[:3]}:{user_offset[3:]}"
-        
+
         if 'T' in date_str:
-            return date_str + formatted_offset
+            return date_str + user_offset
         else:
-            return date_str + f'T00:00:00{formatted_offset}'
+            return date_str + f'T00:00:00{user_offset}'
     
     return date_str
 
@@ -246,6 +245,8 @@ async def get_projects() -> str:
         for i, project in enumerate(projects, 1):
             result += f"Project {i}:\n" + format_project(project) + "\n"
         
+        if failed_projects > 0:
+            result += f"\n⚠️ Note: {failed_projects} projects were skipped due to errors\n"
         return result
     except Exception as e:
         logger.error(f"Error in get_projects: {e}")
@@ -945,26 +946,53 @@ async def get_upcoming_tasks(days: int = 7, project_id: str = None) -> str:
         # Get current time and future cutoff in user timezone
         now = datetime.now(USER_TIMEZONE)
         future_cutoff = now + timedelta(days=days)
-        
+        failed_projects = 0
+
         # Get tasks
         if project_id:
             project_data = ticktick.get_project_with_data(project_id)
             if 'error' in project_data:
                 return f"Error fetching project: {project_data['error']}"
+            projects = [project_data.get('project', {'id': project_id})]
             all_tasks = project_data.get('tasks', [])
-            scope = f"project '{project_data.get('project', {}).get('name', project_id)}'"
+            scope = f"project '{projects[0].get('name', project_id)}'"
         else:
             # Get from all projects
             projects = ticktick.get_projects()
             if 'error' in projects:
                 return f"Error fetching projects: {projects['error']}"
-            
+
+            # Filter active projects and limit to 25
+            active_projects = [p for p in projects if not p.get('closed', False)]
+            if len(active_projects) > 25:
+                logger.info(
+                    f"Limiting search to first 25 active projects out of {len(active_projects)} total"
+                )
+                active_projects = active_projects[:25]
+            projects = active_projects
+            scope = f"{len(projects)} active projects (limited for performance)"
+
+            logger.info(f"Processing {len(projects)} projects for upcoming tasks")
+            if len(projects) > 10:
+                logger.info("Processing more than 10 projects. This may take a while")
+
+            # Fetch tasks from projects
             all_tasks = []
-            for project in projects:
-                project_data = ticktick.get_project_with_data(project['id'])
-                if 'error' not in project_data:
-                    all_tasks.extend(project_data.get('tasks', []))
-            scope = "all projects"
+            for proj in projects:
+                try:
+                    proj_data = ticktick.get_project_with_data(proj['id'])
+                    if 'error' not in proj_data:
+                        all_tasks.extend(proj_data.get('tasks', []))
+                    else:
+                        failed_projects += 1
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to fetch project {proj.get('name', proj['id'])}: {e}"
+                    )
+                    failed_projects += 1
+                    continue
+            if failed_projects > 0:
+                logger.info(f"Skipped {failed_projects} projects due to errors")
         
         # Find upcoming tasks
         upcoming_tasks = []
@@ -1034,6 +1062,8 @@ async def get_upcoming_tasks(days: int = 7, project_id: str = None) -> str:
             if content:
                 content_preview = content[:50] + "..." if len(content) > 50 else content
                 result += f"    📝 {content_preview}\n"
+        if failed_projects > 0:
+            result += f"\n⚠️ Note: {failed_projects} projects were skipped due to errors\n"
         
         return result
         

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -242,9 +242,7 @@ async def get_projects() -> str:
         result = f"Found {len(projects)} projects:\n\n"
         for i, project in enumerate(projects, 1):
             result += f"Project {i}:\n" + format_project(project) + "\n"
-        
-        if failed_projects > 0:
-            result += f"\n⚠️ Note: {failed_projects} projects were skipped due to errors\n"
+
         return result
     except Exception as e:
         logger.error(f"Error in get_projects: {e}")


### PR DESCRIPTION
## Summary
- honor the timezone offset returned by strftime directly
- anchor timezone offset regex when normalizing
- document implicit timezone example in README
- add a unit test for `normalize_datetime_for_user`
- optimize `get_upcoming_tasks` by filtering projects, limiting to 25, and continuing on errors

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684952cc613c832685edfd7d6f254dfd